### PR TITLE
Print and delete cache

### DIFF
--- a/docs/reference/docker_runx.yaml
+++ b/docs/reference/docker_runx.yaml
@@ -5,10 +5,12 @@ usage: docker runx [IMAGE] [ACTION]
 pname: docker
 plink: docker.yaml
 cname:
+    - docker runx cache
     - docker runx decorate
     - docker runx help
     - docker runx version
 clink:
+    - docker_runx_cache.yaml
     - docker_runx_decorate.yaml
     - docker_runx_help.yaml
     - docker_runx_version.yaml

--- a/docs/reference/docker_runx_cache.yaml
+++ b/docs/reference/docker_runx_cache.yaml
@@ -1,0 +1,18 @@
+command: docker runx cache
+short: Manage Docker RunX cache and temporary files
+long: Manage Docker RunX cache and temporary files
+pname: docker runx
+plink: docker_runx.yaml
+cname:
+    - docker runx cache df
+    - docker runx cache prune
+clink:
+    - docker_runx_cache_df.yaml
+    - docker_runx_cache_prune.yaml
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/docs/reference/docker_runx_cache_df.yaml
+++ b/docs/reference/docker_runx_cache_df.yaml
@@ -1,0 +1,13 @@
+command: docker runx cache df
+short: Show disk usage
+long: Show disk usage
+usage: docker runx cache df
+pname: docker runx cache
+plink: docker_runx_cache.yaml
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/docs/reference/docker_runx_cache_prune.yaml
+++ b/docs/reference/docker_runx_cache_prune.yaml
@@ -1,0 +1,25 @@
+command: docker runx cache prune
+short: Remove all cache entries
+long: Remove all cache entries
+usage: docker runx cache prune
+pname: docker runx cache
+plink: docker_runx_cache.yaml
+options:
+    - option: force
+      shorthand: f
+      value_type: bool
+      default_value: "false"
+      description: Do not prompt for confirmation
+      deprecated: false
+      hidden: false
+      experimental: false
+      experimentalcli: false
+      kubernetes: false
+      swarm: false
+deprecated: false
+hidden: false
+experimental: false
+experimentalcli: false
+kubernetes: false
+swarm: false
+

--- a/docs/reference/runx.md
+++ b/docs/reference/runx.md
@@ -7,6 +7,7 @@ Docker Run, better
 
 | Name                           | Description                                      |
 |:-------------------------------|:-------------------------------------------------|
+| [`cache`](runx_cache.md)       | Manage Docker RunX cache and temporary files     |
 | [`decorate`](runx_decorate.md) | Decorate an image by attaching a runx manifest   |
 | [`help`](runx_help.md)         | Display information about the available commands |
 | [`version`](runx_version.md)   | Show Docker RunX version information             |

--- a/docs/reference/runx_cache.md
+++ b/docs/reference/runx_cache.md
@@ -1,0 +1,16 @@
+# docker runx cache
+
+<!---MARKER_GEN_START-->
+Manage Docker RunX cache and temporary files
+
+### Subcommands
+
+| Name                           | Description              |
+|:-------------------------------|:-------------------------|
+| [`df`](runx_cache_df.md)       | Show disk usage          |
+| [`prune`](runx_cache_prune.md) | Remove all cache entries |
+
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/reference/runx_cache_df.md
+++ b/docs/reference/runx_cache_df.md
@@ -1,0 +1,8 @@
+# docker runx cache df
+
+<!---MARKER_GEN_START-->
+Show disk usage
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/reference/runx_cache_prune.md
+++ b/docs/reference/runx_cache_prune.md
@@ -1,0 +1,14 @@
+# docker runx cache prune
+
+<!---MARKER_GEN_START-->
+Remove all cache entries
+
+### Options
+
+| Name            | Type   | Default | Description                    |
+|:----------------|:-------|:--------|:-------------------------------|
+| `-f`, `--force` | `bool` |         | Do not prompt for confirmation |
+
+
+<!---MARKER_GEN_END-->
+

--- a/internal/commands/cache/cache.go
+++ b/internal/commands/cache/cache.go
@@ -3,9 +3,10 @@ package cache
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/docker/cli/cli/command"
 	"github.com/eunomie/docker-runx/internal/constants"
-	"github.com/spf13/cobra"
 )
 
 func NewCmd(dockerCli command.Cli) *cobra.Command {

--- a/internal/commands/cache/cache.go
+++ b/internal/commands/cache/cache.go
@@ -15,7 +15,7 @@ func NewCmd(dockerCli command.Cli) *cobra.Command {
 	}
 	cmd.AddCommand(
 		dfNewCmd(dockerCli),
-		//pruneNewCmd(dockerCli),
+		pruneNewCmd(dockerCli),
 	)
 
 	return cmd

--- a/internal/commands/cache/cache.go
+++ b/internal/commands/cache/cache.go
@@ -1,0 +1,22 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/eunomie/docker-runx/internal/constants"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: fmt.Sprintf("Manage %s cache and temporary files", constants.FullProductName),
+	}
+	cmd.AddCommand(
+		dfNewCmd(dockerCli),
+		//pruneNewCmd(dockerCli),
+	)
+
+	return cmd
+}

--- a/internal/commands/cache/df.go
+++ b/internal/commands/cache/df.go
@@ -1,0 +1,43 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/dustin/go-humanize"
+	"github.com/eunomie/docker-runx/runkit"
+	"github.com/spf13/cobra"
+)
+
+func dfNewCmd(dockerCli command.Cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "df",
+		Short: "Show disk usage",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cache := runkit.NewLocalCache(dockerCli)
+			cacheDir, entries, totalSize, err := cache.ListCache()
+			if err != nil {
+				return err
+			}
+
+			if cacheDir == "" {
+				fmt.Println("No cache directory")
+				return nil
+			}
+
+			str := strings.Builder{}
+			str.WriteString("Cache directory: " + cacheDir + "\n")
+			str.WriteString("\n")
+			for _, e := range entries {
+				str.WriteString(fmt.Sprintf("%s: %s\n", e.Digest, humanize.Bytes(uint64(e.Size))))
+			}
+			str.WriteString(fmt.Sprintf("Total: %s\n", humanize.Bytes(uint64(totalSize))))
+
+			_, _ = fmt.Fprintln(dockerCli.Out(), str.String())
+
+			return nil
+		},
+	}
+}

--- a/internal/commands/cache/df.go
+++ b/internal/commands/cache/df.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/dustin/go-humanize"
-	"github.com/eunomie/docker-runx/runkit"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/eunomie/docker-runx/runkit"
 )
 
 func dfNewCmd(dockerCli command.Cli) *cobra.Command {

--- a/internal/commands/cache/prune.go
+++ b/internal/commands/cache/prune.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/docker/cli/cli/command"
+	"github.com/eunomie/docker-runx/runkit"
+	"github.com/spf13/cobra"
+)
+
+var (
+	force bool
+)
+
+func pruneNewCmd(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove all cache entries",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cache := runkit.NewLocalCache(dockerCli)
+
+			if !force {
+				err := huh.NewForm(
+					huh.NewGroup(
+						huh.NewConfirm().
+							Title("Are you sure you want to remove all cache entries?").
+							Value(&force))).Run()
+				if err != nil {
+					return err
+				}
+			}
+
+			if !force {
+				_, _ = fmt.Fprintln(dockerCli.Out(), "Cancelled")
+				return nil
+			}
+
+			err := cache.Erase()
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintln(dockerCli.Out(), "Cached data deleted")
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&force, "force", "f", false, "Do not prompt for confirmation")
+
+	return cmd
+}

--- a/internal/commands/cache/prune.go
+++ b/internal/commands/cache/prune.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
 	"github.com/docker/cli/cli/command"
 	"github.com/eunomie/docker-runx/runkit"
-	"github.com/spf13/cobra"
 )
 
-var (
-	force bool
-)
+var force bool
 
 func pruneNewCmd(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/eunomie/docker-runx/internal/commands/cache"
-
 	"github.com/charmbracelet/huh/spinner"
 	"github.com/gertd/go-pluralize"
 	"github.com/spf13/cobra"
@@ -16,6 +14,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli-plugins/plugin"
 	"github.com/docker/cli/cli/command"
+	"github.com/eunomie/docker-runx/internal/commands/cache"
 	"github.com/eunomie/docker-runx/internal/commands/decorate"
 	"github.com/eunomie/docker-runx/internal/commands/help"
 	"github.com/eunomie/docker-runx/internal/commands/version"

--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/eunomie/docker-runx/internal/commands/cache"
+
 	"github.com/charmbracelet/huh/spinner"
 	"github.com/gertd/go-pluralize"
 	"github.com/spf13/cobra"
@@ -159,6 +161,7 @@ func NewCmd(dockerCli command.Cli, isPlugin bool) *cobra.Command {
 		help.NewCmd(dockerCli, cmd),
 		version.NewCmd(dockerCli),
 		decorate.NewCmd(dockerCli),
+		cache.NewCmd(dockerCli),
 	)
 
 	f := cmd.Flags()

--- a/runkit/cache.go
+++ b/runkit/cache.go
@@ -112,7 +112,6 @@ func (c *LocalCache) ListCache() (string, []CacheEntry, int64, error) {
 		}
 		return nil
 	})
-
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil, 0, nil

--- a/runkit/cache.go
+++ b/runkit/cache.go
@@ -1,6 +1,8 @@
 package runkit
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -15,9 +17,16 @@ const (
 
 var subCacheDir = filepath.Join(constants.SubCommandName, "cache", "sha256")
 
-type LocalCache struct {
-	cacheDir string
-}
+type (
+	LocalCache struct {
+		cacheDir string
+	}
+
+	CacheEntry struct {
+		Digest string
+		Size   int64
+	}
+)
 
 func NewLocalCache(cli command.Cli) *LocalCache {
 	rootDir := filepath.Dir(cli.ConfigFile().Filename)
@@ -80,4 +89,49 @@ func (c *LocalCache) Set(digest string, runxConfig, runxDoc []byte) error {
 		}
 	}
 	return nil
+}
+
+func (c *LocalCache) ListCache() (string, []CacheEntry, int64, error) {
+	totalSize := int64(0)
+	var entries []CacheEntry
+	err := filepath.WalkDir(c.cacheDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && path != c.cacheDir {
+			s, e := dirSize(path)
+			if e != nil {
+				return e
+			}
+			totalSize += s
+			entries = append(entries, CacheEntry{
+				Digest: filepath.Base(path),
+				Size:   s,
+			})
+			return fs.SkipDir
+		}
+		return nil
+	})
+
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil, 0, nil
+		}
+		return "", nil, 0, err
+	}
+	return c.cacheDir, entries, totalSize, nil
+}
+
+func dirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
 }

--- a/runkit/cache.go
+++ b/runkit/cache.go
@@ -122,6 +122,10 @@ func (c *LocalCache) ListCache() (string, []CacheEntry, int64, error) {
 	return c.cacheDir, entries, totalSize, nil
 }
 
+func (c *LocalCache) Erase() error {
+	return os.RemoveAll(c.cacheDir)
+}
+
 func dirSize(path string) (int64, error) {
 	var size int64
 	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {


### PR DESCRIPTION
Allow to print cache usage with `docker runx cache df` and to delete all cached entries with `docker runx cache prune`.

Fixes #2 