### PR TITLE
Image references

### DIFF
--- a/internal/commands/root/root.go
+++ b/internal/commands/root/root.go
@@ -112,7 +112,7 @@ func NewCmd(dockerCli command.Cli, isPlugin bool) *cobra.Command {
 					return nil
 				}
 
-				action = selectAction(action, lc.Images[src], rk.Config.Default)
+				action = selectAction(action, src, rk.Config.Default)
 
 				if list || action == "" {
 					if tui.IsATTY(dockerCli.In().FD()) && len(rk.Config.Actions) > 0 {
@@ -176,7 +176,7 @@ func getValuesLocal(src, action string) map[string]string {
 	localOpts := make(map[string]string)
 
 	lc := runkit.GetLocalConfig()
-	img, ok := lc.Images[src]
+	img, ok := lc.Image(src)
 	if !ok {
 		return localOpts
 	}
@@ -235,12 +235,12 @@ func run(ctx context.Context, out io.Writer, src string, rk *runkit.RunKit, acti
 	return runnable.Run(ctx)
 }
 
-func selectAction(action string, conf runkit.ConfigImage, defaultAction string) string {
+func selectAction(action, src, defaultAction string) string {
 	if action != "" {
 		return action
 	}
 
-	if conf.Default != "" {
+	if conf, ok := runkit.GetLocalConfig().Image(src); ok && conf.Default != "" {
 		return conf.Default
 	}
 

--- a/runkit/cache.go
+++ b/runkit/cache.go
@@ -37,7 +37,7 @@ func NewLocalCache(cli command.Cli) *LocalCache {
 	}
 }
 
-func (c *LocalCache) Get(digest string) (*RunKit, error) {
+func (c *LocalCache) Get(digest, src string) (*RunKit, error) {
 	rk := &RunKit{
 		Files: make(map[string]string),
 	}
@@ -66,6 +66,7 @@ func (c *LocalCache) Get(digest string) (*RunKit, error) {
 	}
 
 	if found {
+		rk.src = src
 		return rk, nil
 	}
 	return nil, nil

--- a/runkit/read.go
+++ b/runkit/read.go
@@ -25,7 +25,7 @@ type (
 	}
 
 	Cache interface {
-		Get(digest string) (*RunKit, error)
+		Get(digest, src string) (*RunKit, error)
 		Set(digest string, runxConfig, runxDoc []byte) error
 	}
 )
@@ -60,7 +60,7 @@ func Get(ctx context.Context, cache Cache, src string) (*RunKit, error) {
 
 	indexDigest = desc.Digest.String()
 
-	cached, err = cache.Get(indexDigest)
+	cached, err = cache.Get(indexDigest, src)
 	if err == nil && cached != nil {
 		return cached, nil
 	}


### PR DESCRIPTION
Match images after parsing their references.
That way `NAMESPACE/REPO` will match `docker.io/NAMESPACE/REPO:latest` for instance.

Fixes #6 