### PR TITLE
feat: support confirm (boolean) values

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ actions:
     # A list of options that can be provided by the user.
     opts:
       - name: OPTION_NAME # Name of the option. Also used in the local override or with `--opt` flag.
+        type: input|select|confirm # Type of the option.
         desc: DESCRIPTION # Description, rendered in the documentation of the action.
         prompt: PROMPT # A specific prompt to ask the user for the value.
         no-prompt: true|false # If set to true, the option will not be prompted to the user.
@@ -155,6 +156,8 @@ actions:
     #   The environment variable needs to be defined in the `env` section.
     # - `{{opt "OPTION"}}` will be replaced by the value of the option `OPTION`.
     #   The value needs to be provided by the local configuration, on the command line or interactively.
+    # - `{{optBool "OPTION"}}` is equivalent to `{{opt "OPTION"}}` but will return the value as a boolean.
+    #   True values are `1`, `t`, `T`, `TRUE`, `true` and `True`. Everything else is considered as false.
     # - `{{sh "COMMAND"}}` will be replaced by the output of the shell command `COMMAND`.
     #   The command will be run using https://github.com/mvdan/sh without a standard input.
     cmd: COMMAND

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -130,6 +130,7 @@ actions:
     # A list of options that can be provided by the user.
     opts:
       - name: OPTION_NAME # Name of the option. Also used in the local override or with `--opt` flag.
+        type: input|select|confirm # Type of the option.
         desc: DESCRIPTION # Description, rendered in the documentation of the action.
         prompt: PROMPT # A specific prompt to ask the user for the value.
         no-prompt: true|false # If set to true, the option will not be prompted to the user.
@@ -148,6 +149,8 @@ actions:
     #   The environment variable needs to be defined in the `env` section.
     # - `{{opt "OPTION"}}` will be replaced by the value of the option `OPTION`.
     #   The value needs to be provided by the local configuration, on the command line or interactively.
+    # - `{{optBool "OPTION"}}` is equivalent to `{{opt "OPTION"}}` but will return the value as a boolean.
+    #   True values are `1`, `t`, `T`, `TRUE`, `true` and `True`. Everything else is considered as false.
     # - `{{sh "COMMAND"}}` will be replaced by the output of the shell command `COMMAND`.
     #   The command will be run using https://github.com/mvdan/sh without a standard input.
     cmd: COMMAND

--- a/runkit/read.go
+++ b/runkit/read.go
@@ -188,6 +188,17 @@ func decodeConfig(rk *RunKit, src string, runxConfig []byte) error {
 			a.isDefault = true
 		}
 
+		for i, o := range a.Options {
+			if o.Type == OptTypeNotSet {
+				if len(o.Values) > 0 {
+					o.Type = OptTypeSelect
+				} else {
+					o.Type = OptTypeInput
+				}
+				a.Options[i] = o
+			}
+		}
+
 		actions = append(actions, a)
 	}
 	config.Actions = actions

--- a/runkit/run.go
+++ b/runkit/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -117,6 +118,14 @@ func (r *Runnable) compute() error {
 		},
 		"opt": func(optName string) string {
 			return r.data.Opts[optName]
+		},
+		"optBool": func(optName string) bool {
+			o, ok := r.data.Opts[optName]
+			if !ok {
+				return false
+			}
+			v, _ := strconv.ParseBool(o)
+			return v
 		},
 		"sh": func(cmdName string) (string, error) {
 			v, ok := shells[cmdName]

--- a/runkit/types.go
+++ b/runkit/types.go
@@ -29,6 +29,7 @@ type (
 
 	Opt struct {
 		Name        string   `yaml:"name" json:"name"`
+		Type        OptType  `yaml:"type,omitempty" json:"type,omitempty"`
 		Description string   `yaml:"desc" json:"desc,omitempty"`
 		NoPrompt    bool     `yaml:"no-prompt,omitempty" json:"no-prompt,omitempty"`
 		Prompt      string   `yaml:"prompt,omitempty" json:"prompt,omitempty"`
@@ -38,6 +39,8 @@ type (
 	}
 
 	ActionType string
+
+	OptType string
 
 	LocalConfig struct {
 		Ref    string                 `yaml:"ref,omitempty" json:"ref,omitempty"`
@@ -58,8 +61,13 @@ type (
 const (
 	ActionTypeRun   ActionType = "run"
 	ActionTypeBuild ActionType = "build"
+
+	OptTypeNotSet  OptType = ""
+	OptTypeInput   OptType = "input"
+	OptTypeSelect  OptType = "select"
+	OptTypeConfirm OptType = "confirm"
 )
 
-func (a *Action) IsDefault() bool {
-	return a.isDefault
+func (action *Action) IsDefault() bool {
+	return action.isDefault
 }


### PR DESCRIPTION
Use `optBool` to convert any value to a boolean to be used in the template.

A new `type` field can be set for an option.
Possible values are:

- input: text field
- select: single select field
- confirm: ask for a yes/no confirmation

If no type is set, if some values are set type will be select, else it will be an input. This is just for backward compatibility, type should be set.

Fixes #9 