### PR TITLE
feat: correctly handle yaml strings

### DIFF
--- a/internal/pizza/slice.go
+++ b/internal/pizza/slice.go
@@ -1,6 +1,9 @@
 package pizza
 
 func Map[I, R interface{}](objs []I, fn func(obj I) R) []R {
+	if len(objs) == 0 {
+		return nil
+	}
 	s := []R{}
 	for _, obj := range objs {
 		s = append(s, fn(obj))

--- a/internal/runx/run.go
+++ b/internal/runx/run.go
@@ -59,7 +59,7 @@ func Run(ctx context.Context, out io.Writer, rk *runkit.RunKit, lc *runkit.Local
     %s
 
 ---
-`, runnable.Command)
+`, "\n```\n"+runnable.Command+"\n```\n")
 
 	var flags []string
 	if !runConfig.NoConfirm && !lc.AcceptTheRisk {

--- a/runkit/read.go
+++ b/runkit/read.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -175,9 +174,6 @@ func decodeConfig(rk *RunKit, src string, runxConfig []byte) error {
 	}
 	var actions []Action
 	for _, a := range config.Actions {
-		// TODO: fix reading of multiline YAML strings
-		a.Command = strings.ReplaceAll(a.Command, "\n", " ")
-
 		if a.Dockerfile != "" {
 			if c, ok := rk.Files[a.Dockerfile]; ok {
 				a.DockerfileContent = c

--- a/runkit/run.go
+++ b/runkit/run.go
@@ -14,6 +14,7 @@ import (
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/syntax"
 
+	"github.com/eunomie/docker-runx/internal/pizza"
 	"github.com/eunomie/docker-runx/internal/tui"
 )
 
@@ -186,7 +187,7 @@ func (r *Runnable) CheckFlags() ([]string, error) {
 	if r.Action.Type != ActionTypeRun {
 		return nil, nil
 	}
-	tokens, err := shlex.Split(r.args)
+	tokens, err := splitArgs(r.args)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +198,7 @@ func (r *Runnable) CheckFlags() ([]string, error) {
 	}
 	if f.NArg() > 0 {
 		args, _, _ := strings.Cut(r.args, f.Arg(0))
-		tokens, err = shlex.Split(args)
+		tokens, err = splitArgs(args)
 		if err != nil {
 			return nil, err
 		}
@@ -215,6 +216,11 @@ func (r *Runnable) CheckFlags() ([]string, error) {
 	})
 
 	return flagsSet, nil
+}
+
+func splitArgs(args string) ([]string, error) {
+	tokens, err := shlex.Split(args)
+	return pizza.Map(tokens, strings.TrimSpace), err
 }
 
 func (r *Runnable) Run(ctx context.Context) error {


### PR DESCRIPTION
Both > and | are handled
I suggest to only use | with \ at the end of the line, so the command will be easier to read and copy paste for the user. But > will be handled and newlines will be removed.

Fixes #11 